### PR TITLE
Implements autoconfiguration of assets.package tag

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -13,6 +13,7 @@ CHANGELOG
  * added `framework.http_client.retry_failing` configuration tree
  * added `assertCheckboxChecked()` and `assertCheckboxNotChecked()` in `WebTestCase`
  * added `assertFormValue()` and `assertNoFormValue()` in `WebTestCase`
+ * Added tag `assets.package` to register asset packages
 
 5.1.0
 -----

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/UnusedTagsPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/UnusedTagsPass.php
@@ -23,6 +23,7 @@ class UnusedTagsPass implements CompilerPassInterface
 {
     private $knownTags = [
         'annotations.cached_reader',
+        'assets.package',
         'auto_alias',
         'cache.pool',
         'cache.pool.clearer',

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1057,7 +1057,6 @@ class FrameworkExtension extends Extension
         $defaultPackage = $this->createPackageDefinition($config['base_path'], $config['base_urls'], $defaultVersion);
         $container->setDefinition('assets._default_package', $defaultPackage);
 
-        $namedPackages = [];
         foreach ($config['packages'] as $name => $package) {
             if (null !== $package['version_strategy']) {
                 $version = new Reference($package['version_strategy']);
@@ -1071,15 +1070,11 @@ class FrameworkExtension extends Extension
                 $version = $this->createVersion($container, $version, $format, $package['json_manifest_path'], $name);
             }
 
-            $container->setDefinition('assets._package_'.$name, $this->createPackageDefinition($package['base_path'], $package['base_urls'], $version));
+            $packageDefinition = $this->createPackageDefinition($package['base_path'], $package['base_urls'], $version)
+                ->addTag('assets.package', ['package' => $name]);
+            $container->setDefinition('assets._package_'.$name, $packageDefinition);
             $container->registerAliasForArgument('assets._package_'.$name, PackageInterface::class, $name.'.package');
-            $namedPackages[$name] = new Reference('assets._package_'.$name);
         }
-
-        $container->getDefinition('assets.packages')
-            ->replaceArgument(0, new Reference('assets._default_package'))
-            ->replaceArgument(1, $namedPackages)
-        ;
     }
 
     /**

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/assets.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/assets.php
@@ -30,8 +30,8 @@ return static function (ContainerConfigurator $container) {
     $container->services()
         ->set('assets.packages', Packages::class)
             ->args([
-                service('assets.empty_package'),
-                [],
+                service('assets._default_package'),
+                tagged_iterator('assets.package', 'package'),
             ])
 
         ->alias(Packages::class, 'assets.packages')
@@ -40,6 +40,8 @@ return static function (ContainerConfigurator $container) {
             ->args([
                 service('assets.empty_version_strategy'),
             ])
+
+        ->alias('assets._default_package', 'assets.empty_package')
 
         ->set('assets.context', RequestStackContext::class)
             ->args([

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/assets.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/assets.php
@@ -31,7 +31,7 @@ return static function (ContainerConfigurator $container) {
         ->set('assets.packages', Packages::class)
             ->args([
                 service('assets._default_package'),
-                tagged_iterator('assets.package', 'package'),
+                tagged_iterator('assets.package'),
             ])
 
         ->alias(Packages::class, 'assets.packages')
@@ -53,6 +53,7 @@ return static function (ContainerConfigurator $container) {
         ->set('assets.path_package', PathPackage::class)
             ->abstract()
             ->args([
+                abstract_arg('name'),
                 abstract_arg('base path'),
                 abstract_arg('version strategy'),
                 service('assets.context'),
@@ -61,6 +62,7 @@ return static function (ContainerConfigurator $container) {
         ->set('assets.url_package', UrlPackage::class)
             ->abstract()
             ->args([
+                abstract_arg('name'),
                 abstract_arg('base URLs'),
                 abstract_arg('version strategy'),
                 service('assets.context'),

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -61,10 +61,10 @@ use Symfony\Component\Translation\DependencyInjection\TranslatorPass;
 use Symfony\Component\Validator\DependencyInjection\AddConstraintValidatorsPass;
 use Symfony\Component\Validator\Mapping\Loader\PropertyInfoLoader;
 use Symfony\Component\Workflow;
+use Symfony\Component\Workflow\Metadata\InMemoryMetadataStore;
 use Symfony\Component\Workflow\WorkflowEvents;
 use Symfony\Contracts\Cache\CacheInterface;
 use Symfony\Contracts\Cache\TagAwareCacheInterface;
-use Symfony\Component\Workflow\Metadata\InMemoryMetadataStore;
 
 abstract class FrameworkExtensionTest extends TestCase
 {
@@ -578,8 +578,13 @@ abstract class FrameworkExtensionTest extends TestCase
         $this->assertUrlPackage($container, $defaultPackage, ['http://cdn.example.com'], 'SomeVersionScheme', '%%s?version=%%s');
 
         // packages
-        $packages = $packages->getArgument(1);
-        $this->assertCount(7, $packages);
+        $packageTags = $container->findTaggedServiceIds('assets.package');
+        $this->assertCount(7, $packageTags);
+
+        $packages = [];
+        foreach ($packageTags as $serviceId => $tagAttributes) {
+            $packages[$tagAttributes[0]['package']] = $serviceId;
+        }
 
         $package = $container->getDefinition((string) $packages['images_path']);
         $this->assertPathPackage($container, $package, '/foo', 'SomeVersionScheme', '%%s?version=%%s');

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -579,29 +579,30 @@ abstract class FrameworkExtensionTest extends TestCase
 
         // packages
         $packageTags = $container->findTaggedServiceIds('assets.package');
-        $this->assertCount(7, $packageTags);
+        $this->assertCount(8, $packageTags);
 
         $packages = [];
         foreach ($packageTags as $serviceId => $tagAttributes) {
-            $packages[$tagAttributes[0]['package']] = $serviceId;
+            $package = $container->getDefinition($serviceId);
+            $packages[$package->getArgument(0)] = $package;
         }
 
-        $package = $container->getDefinition((string) $packages['images_path']);
+        $package = $packages['images_path'];
         $this->assertPathPackage($container, $package, '/foo', 'SomeVersionScheme', '%%s?version=%%s');
 
-        $package = $container->getDefinition((string) $packages['images']);
+        $package = $packages['images'];
         $this->assertUrlPackage($container, $package, ['http://images1.example.com', 'http://images2.example.com'], '1.0.0', '%%s?version=%%s');
 
-        $package = $container->getDefinition((string) $packages['foo']);
+        $package = $packages['foo'];
         $this->assertPathPackage($container, $package, '', '1.0.0', '%%s-%%s');
 
-        $package = $container->getDefinition((string) $packages['bar']);
+        $package = $packages['bar'];
         $this->assertUrlPackage($container, $package, ['https://bar2.example.com'], 'SomeVersionScheme', '%%s?version=%%s');
 
-        $package = $container->getDefinition((string) $packages['bar_version_strategy']);
+        $package = $packages['bar_version_strategy'];
         $this->assertEquals('assets.custom_version_strategy', (string) $package->getArgument(1));
 
-        $package = $container->getDefinition((string) $packages['json_manifest_strategy']);
+        $package = $packages['json_manifest_strategy'];
         $versionStrategy = $container->getDefinition((string) $package->getArgument(1));
         $this->assertEquals('assets.json_manifest_version_strategy', $versionStrategy->getParent());
         $this->assertEquals('/path/to/manifest.json', $versionStrategy->getArgument(0));

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -34,7 +34,7 @@
     "require-dev": {
         "doctrine/annotations": "~1.7",
         "doctrine/cache": "~1.0",
-        "symfony/asset": "^5.1",
+        "symfony/asset": "^5.2",
         "symfony/browser-kit": "^4.4|^5.0",
         "symfony/console": "^5.2",
         "symfony/css-selector": "^4.4|^5.0",
@@ -71,7 +71,7 @@
         "phpdocumentor/reflection-docblock": "<3.0",
         "phpdocumentor/type-resolver": "<0.2.1",
         "phpunit/phpunit": "<5.4.3",
-        "symfony/asset": "<5.1",
+        "symfony/asset": "<5.2",
         "symfony/browser-kit": "<4.4",
         "symfony/console": "<5.2",
         "symfony/dotenv": "<5.1",

--- a/src/Symfony/Component/Asset/CHANGELOG.md
+++ b/src/Symfony/Component/Asset/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+5.2.0
+-----
+
+ * the `Packages` constructor accepts any iterable.
+
 5.1.0
 -----
 

--- a/src/Symfony/Component/Asset/CHANGELOG.md
+++ b/src/Symfony/Component/Asset/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+6.0.0
+-----
+
+ * [BC break] added method `PackageInterface::getName()` and modified `Packages`
+  contructor and `Packages::addPackage()` to get the name from the package.
+
 5.2.0
 -----
 

--- a/src/Symfony/Component/Asset/Package.php
+++ b/src/Symfony/Component/Asset/Package.php
@@ -23,11 +23,13 @@ use Symfony\Component\Asset\VersionStrategy\VersionStrategyInterface;
  */
 class Package implements PackageInterface
 {
+    private $name;
     private $versionStrategy;
     private $context;
 
-    public function __construct(VersionStrategyInterface $versionStrategy, ContextInterface $context = null)
+    public function __construct(string $name, VersionStrategyInterface $versionStrategy, ContextInterface $context = null)
     {
+        $this->name = $name;
         $this->versionStrategy = $versionStrategy;
         $this->context = $context ?: new NullContext();
     }
@@ -50,6 +52,14 @@ class Package implements PackageInterface
         }
 
         return $this->versionStrategy->applyVersion($path);
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
     }
 
     /**

--- a/src/Symfony/Component/Asset/PackageInterface.php
+++ b/src/Symfony/Component/Asset/PackageInterface.php
@@ -31,4 +31,12 @@ interface PackageInterface
      * @return string The public path
      */
     public function getUrl(string $path);
+
+
+    /**
+     * Returns the name of the package.
+     *
+     * @return string The package name
+     */
+    public function getName();
 }

--- a/src/Symfony/Component/Asset/Packages.php
+++ b/src/Symfony/Component/Asset/Packages.php
@@ -28,7 +28,7 @@ class Packages
     /**
      * @param PackageInterface[] $packages Additional packages indexed by name
      */
-    public function __construct(PackageInterface $defaultPackage = null, array $packages = [])
+    public function __construct(PackageInterface $defaultPackage = null, iterable $packages = [])
     {
         $this->defaultPackage = $defaultPackage;
 

--- a/src/Symfony/Component/Asset/Packages.php
+++ b/src/Symfony/Component/Asset/Packages.php
@@ -32,8 +32,8 @@ class Packages
     {
         $this->defaultPackage = $defaultPackage;
 
-        foreach ($packages as $name => $package) {
-            $this->addPackage($name, $package);
+        foreach ($packages as $package) {
+            $this->addPackage($package);
         }
     }
 
@@ -42,9 +42,9 @@ class Packages
         $this->defaultPackage = $defaultPackage;
     }
 
-    public function addPackage(string $name, PackageInterface $package)
+    public function addPackage(PackageInterface $package)
     {
-        $this->packages[$name] = $package;
+        $this->packages[$package->getName()] = $package;
     }
 
     /**

--- a/src/Symfony/Component/Asset/PathPackage.php
+++ b/src/Symfony/Component/Asset/PathPackage.php
@@ -31,9 +31,9 @@ class PathPackage extends Package
     /**
      * @param string $basePath The base path to be prepended to relative paths
      */
-    public function __construct(string $basePath, VersionStrategyInterface $versionStrategy, ContextInterface $context = null)
+    public function __construct(string $name, string $basePath, VersionStrategyInterface $versionStrategy, ContextInterface $context = null)
     {
-        parent::__construct($versionStrategy, $context);
+        parent::__construct($name, $versionStrategy, $context);
 
         if (!$basePath) {
             $this->basePath = '/';

--- a/src/Symfony/Component/Asset/Tests/PackageTest.php
+++ b/src/Symfony/Component/Asset/Tests/PackageTest.php
@@ -23,7 +23,7 @@ class PackageTest extends TestCase
      */
     public function testGetUrl($version, $format, $path, $expected)
     {
-        $package = new Package($version ? new StaticVersionStrategy($version, $format) : new EmptyVersionStrategy());
+        $package = new Package('name', $version ? new StaticVersionStrategy($version, $format) : new EmptyVersionStrategy());
         $this->assertSame($expected, $package->getUrl($path));
     }
 
@@ -47,9 +47,15 @@ class PackageTest extends TestCase
         ];
     }
 
+    public function testGetName()
+    {
+        $package = new Package('name', new StaticVersionStrategy('v1'));
+        $this->assertSame('name', $package->getName());
+    }
+
     public function testGetVersion()
     {
-        $package = new Package(new StaticVersionStrategy('v1'));
+        $package = new Package('name', new EmptyVersionStrategy());
         $this->assertSame('v1', $package->getVersion('/foo'));
     }
 }

--- a/src/Symfony/Component/Asset/Tests/PackagesTest.php
+++ b/src/Symfony/Component/Asset/Tests/PackagesTest.php
@@ -48,7 +48,7 @@ class PackagesTest extends TestCase
     {
         $packages = new Packages(
             new Package(new StaticVersionStrategy('default')),
-            ['a' => new Package(new StaticVersionStrategy('a'))]
+            new \ArrayIterator(['a' => new Package(new StaticVersionStrategy('a'))])
         );
 
         $this->assertSame('/foo?default', $packages->getUrl('/foo'));

--- a/src/Symfony/Component/Asset/Tests/PackagesTest.php
+++ b/src/Symfony/Component/Asset/Tests/PackagesTest.php
@@ -22,7 +22,7 @@ class PackagesTest extends TestCase
     {
         $packages = new Packages();
         $packages->setDefaultPackage($default = $this->getMockBuilder('Symfony\Component\Asset\PackageInterface')->getMock());
-        $packages->addPackage('a', $a = $this->getMockBuilder('Symfony\Component\Asset\PackageInterface')->getMock());
+        $packages->addPackage($a = $this->getMockBuilder('Symfony\Component\Asset\PackageInterface')->method('getName')->willReturn('a')->getMock());
 
         $this->assertSame($default, $packages->getPackage());
         $this->assertSame($a, $packages->getPackage('a'));
@@ -37,7 +37,7 @@ class PackagesTest extends TestCase
     {
         $packages = new Packages(
             new Package(new StaticVersionStrategy('default')),
-            ['a' => new Package(new StaticVersionStrategy('a'))]
+            [new Package('a', new StaticVersionStrategy('a'))]
         );
 
         $this->assertSame('default', $packages->getVersion('/foo'));
@@ -47,8 +47,8 @@ class PackagesTest extends TestCase
     public function testGetUrl()
     {
         $packages = new Packages(
-            new Package(new StaticVersionStrategy('default')),
-            new \ArrayIterator(['a' => new Package(new StaticVersionStrategy('a'))])
+            new Package('default', new StaticVersionStrategy('default')),
+            new \ArrayIterator([new Package('a', new StaticVersionStrategy('a'))])
         );
 
         $this->assertSame('/foo?default', $packages->getUrl('/foo'));

--- a/src/Symfony/Component/Asset/Tests/PathPackageTest.php
+++ b/src/Symfony/Component/Asset/Tests/PathPackageTest.php
@@ -22,7 +22,7 @@ class PathPackageTest extends TestCase
      */
     public function testGetUrl($basePath, $format, $path, $expected)
     {
-        $package = new PathPackage($basePath, new StaticVersionStrategy('v1', $format));
+        $package = new PathPackage('name', $basePath, new StaticVersionStrategy('v1', $format));
         $this->assertSame($expected, $package->getUrl($path));
     }
 
@@ -53,7 +53,7 @@ class PathPackageTest extends TestCase
      */
     public function testGetUrlWithContext($basePathRequest, $basePath, $format, $path, $expected)
     {
-        $package = new PathPackage($basePath, new StaticVersionStrategy('v1', $format), $this->getContext($basePathRequest));
+        $package = new PathPackage('name', $basePath, new StaticVersionStrategy('v1', $format), $this->getContext($basePathRequest));
 
         $this->assertSame($expected, $package->getUrl($path));
     }
@@ -81,7 +81,7 @@ class PathPackageTest extends TestCase
         $versionStrategy->expects($this->any())
             ->method('applyVersion')
             ->willReturn('https://cdn.com/bar/main.css');
-        $package = new PathPackage('/subdirectory', $versionStrategy, $this->getContext('/bar'));
+        $package = new PathPackage('name', '/subdirectory', $versionStrategy, $this->getContext('/bar'));
 
         $this->assertSame('https://cdn.com/bar/main.css', $package->getUrl('main.css'));
     }

--- a/src/Symfony/Component/Asset/Tests/UrlPackageTest.php
+++ b/src/Symfony/Component/Asset/Tests/UrlPackageTest.php
@@ -23,7 +23,7 @@ class UrlPackageTest extends TestCase
      */
     public function testGetUrl($baseUrls, $format, $path, $expected)
     {
-        $package = new UrlPackage($baseUrls, new StaticVersionStrategy('v1', $format));
+        $package = new UrlPackage('name', $baseUrls, new StaticVersionStrategy('v1', $format));
         $this->assertSame($expected, $package->getUrl($path));
     }
 
@@ -63,7 +63,7 @@ class UrlPackageTest extends TestCase
      */
     public function testGetUrlWithContext($secure, $baseUrls, $format, $path, $expected)
     {
-        $package = new UrlPackage($baseUrls, new StaticVersionStrategy('v1', $format), $this->getContext($secure));
+        $package = new UrlPackage('name', $baseUrls, new StaticVersionStrategy('v1', $format), $this->getContext($secure));
 
         $this->assertSame($expected, $package->getUrl($path));
     }
@@ -90,7 +90,7 @@ class UrlPackageTest extends TestCase
         $versionStrategy->expects($this->any())
             ->method('applyVersion')
             ->willReturn('https://cdn.com/bar/main.css');
-        $package = new UrlPackage('https://example.com', $versionStrategy);
+        $package = new UrlPackage('name', 'https://example.com', $versionStrategy);
 
         $this->assertSame('https://cdn.com/bar/main.css', $package->getUrl('main.css'));
     }
@@ -98,7 +98,7 @@ class UrlPackageTest extends TestCase
     public function testNoBaseUrls()
     {
         $this->expectException('Symfony\Component\Asset\Exception\LogicException');
-        new UrlPackage([], new EmptyVersionStrategy());
+        new UrlPackage('name', [], new EmptyVersionStrategy());
     }
 
     /**
@@ -107,7 +107,7 @@ class UrlPackageTest extends TestCase
     public function testWrongBaseUrl($baseUrls)
     {
         $this->expectException('Symfony\Component\Asset\Exception\InvalidArgumentException');
-        new UrlPackage($baseUrls, new EmptyVersionStrategy());
+        new UrlPackage('name', $baseUrls, new EmptyVersionStrategy());
     }
 
     public function getWrongBaseUrlConfig()

--- a/src/Symfony/Component/Asset/UrlPackage.php
+++ b/src/Symfony/Component/Asset/UrlPackage.php
@@ -41,9 +41,9 @@ class UrlPackage extends Package
     /**
      * @param string|string[] $baseUrls Base asset URLs
      */
-    public function __construct($baseUrls, VersionStrategyInterface $versionStrategy, ContextInterface $context = null)
+    public function __construct(string $name, $baseUrls, VersionStrategyInterface $versionStrategy, ContextInterface $context = null)
     {
-        parent::__construct($versionStrategy, $context);
+        parent::__construct($name, $versionStrategy, $context);
 
         if (!\is_array($baseUrls)) {
             $baseUrls = (array) $baseUrls;


### PR DESCRIPTION
Trying to implements autoconfiguration of tag `assets.package` for `PackageInterface` (https://github.com/symfony/symfony/pull/38366#pullrequestreview-500313994). We needs the package name; adding the method `PackageInterface::getName()` introduces some breaking changes.