### PR TITLE
[DoctrineBridge] Rename `UniqueEntity` `$em` option to `$manager` as it is also used in ODM

### DIFF
--- a/UPGRADE-7.4.md
+++ b/UPGRADE-7.4.md
@@ -34,6 +34,7 @@ DoctrineBridge
 --------------
 
  * Deprecate `UniqueEntity::getRequiredOptions()` and `UniqueEntity::getDefaultOption()`
+ * Rename `UniqueEntity` `$em` option to `$manager` as it is also used for document managers
 
 DomCrawler
 ----------

--- a/src/Symfony/Bridge/Doctrine/CHANGELOG.md
+++ b/src/Symfony/Bridge/Doctrine/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Deprecate `UniqueEntity::getRequiredOptions()` and `UniqueEntity::getDefaultOption()`
  * Use a single table named `_schema_subscriber_check` in schema listeners to detect same database connections
+ * Rename `UniqueEntity` `$em` option to `$manager` as it is also used for document managers
 
 7.3
 ---

--- a/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueEntityTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueEntityTest.php
@@ -44,7 +44,7 @@ class UniqueEntityTest extends TestCase
         [$constraint] = $metadata->getConstraints();
         self::assertSame(['isbn'], $constraint->fields);
         self::assertSame('my_own_validator', $constraint->validatedBy());
-        self::assertSame('my_own_entity_manager', $constraint->em);
+        self::assertSame('my_own_entity_manager', $constraint->manager);
         self::assertSame('App\Entity\MyEntity', $constraint->entityClass);
         self::assertSame('fetchDifferently', $constraint->repositoryMethod);
     }

--- a/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueEntityValidatorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueEntityValidatorTest.php
@@ -163,7 +163,7 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
         yield 'Doctrine style' => [new UniqueEntity([
             'message' => 'myMessage',
             'fields' => ['name'],
-            'em' => self::EM_NAME,
+            'manager' => self::EM_NAME,
         ])];
 
         yield 'Named arguments' => [new UniqueEntity(message: 'myMessage', fields: ['name'], em: 'foo')];
@@ -203,7 +203,7 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
 
         $this->validator->validate($entity, new UniqueEntity([
             'fields' => ['name'],
-            'em' => self::EM_NAME,
+            'manager' => self::EM_NAME,
         ]));
 
         $this->assertNoViolation();
@@ -241,7 +241,7 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
         $this->validator->validate($entity2, new UniqueEntity([
             'message' => 'myMessage',
             'fields' => ['name'],
-            'em' => 'foo',
+            'manager' => 'foo',
             'errorPath' => 'bar',
         ]));
 
@@ -952,7 +952,7 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
         $constraint = new UniqueEntity([
             'message' => 'myMessage',
             'fields' => ['name'],
-            'em' => self::EM_NAME,
+            'manager' => self::EM_NAME,
             'entityClass' => Person::class,
         ]);
 
@@ -1014,7 +1014,7 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
         $constraint = new UniqueEntity([
             'message' => 'myMessage',
             'fields' => ['primaryName' => 'name', 'secondaryName' => 'name2'],
-            'em' => self::EM_NAME,
+            'manager' => self::EM_NAME,
             'entityClass' => DoubleNameEntity::class,
         ]);
 
@@ -1059,7 +1059,7 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
         $constraint = new UniqueEntity([
             'message' => 'myMessage',
             'fields' => ['primaryName' => 'name'],
-            'em' => self::EM_NAME,
+            'manager' => self::EM_NAME,
             'entityClass' => SingleStringIdEntity::class,
         ]);
 
@@ -1091,7 +1091,7 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
         $constraint = new UniqueEntity([
             'message' => 'myMessage',
             'fields' => ['name2'],
-            'em' => self::EM_NAME,
+            'manager' => self::EM_NAME,
             'entityClass' => SingleStringIdEntity::class,
         ]);
 
@@ -1136,7 +1136,7 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
         $constraint = new UniqueEntity([
             'message' => 'myMessage',
             'fields' => ['name'],
-            'em' => self::EM_NAME,
+            'manager' => self::EM_NAME,
             'entityClass' => Person::class,
             'identifierFieldNames' => ['id'],
         ]);
@@ -1190,7 +1190,7 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
         $constraint = new UniqueEntity([
             'message' => 'myMessage',
             'fields' => ['name'],
-            'em' => self::EM_NAME,
+            'manager' => self::EM_NAME,
             'entityClass' => CompositeIntIdEntity::class,
             'identifierFieldNames' => ['id1', 'id2'],
         ]);
@@ -1243,7 +1243,7 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
         $constraint = new UniqueEntity([
             'message' => 'myMessage',
             'fields' => ['object1' => 'objectOne', 'object2' => 'objectTwo'],
-            'em' => self::EM_NAME,
+            'manager' => self::EM_NAME,
             'entityClass' => CompositeObjectNoToStringIdEntity::class,
             'identifierFieldNames' => ['object1' => 'objectOne', 'object2' => 'objectTwo'],
         ]);
@@ -1304,7 +1304,7 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
         $constraint = new UniqueEntity([
             'message' => 'myMessage',
             'fields' => ['object1' => 'objectOne', 'object2' => 'objectTwo'],
-            'em' => self::EM_NAME,
+            'manager' => self::EM_NAME,
             'entityClass' => CompositeObjectNoToStringIdEntity::class,
             'identifierFieldNames' => ['object2' => 'objectTwo'],
         ]);
@@ -1352,7 +1352,7 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
         $constraint = new UniqueEntity([
             'message' => 'myMessage',
             'fields' => ['foo' => 'name'],
-            'em' => self::EM_NAME,
+            'manager' => self::EM_NAME,
             'entityClass' => DoubleNameEntity::class,
         ]);
 

--- a/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntity.php
+++ b/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntity.php
@@ -30,7 +30,11 @@ class UniqueEntity extends Constraint
 
     public string $message = 'This value is already used.';
     public string $service = 'doctrine.orm.validator.unique';
+    /**
+     * @deprecated since Symfony 7.4, use $manager instead
+     */
     public ?string $em = null;
+    public ?string $manager = null;
     public ?string $entityClass = null;
     public string $repositoryMethod = 'findBy';
     public array|string $fields = [];
@@ -41,18 +45,19 @@ class UniqueEntity extends Constraint
     /**
      * @param array|string         $fields           The combination of fields that must contain unique values or a set of options
      * @param bool|string[]|string $ignoreNull       The combination of fields that ignore null values
-     * @param string|null          $em               The entity manager used to query for uniqueness instead of the manager of this class
+     * @param string|null          $manager          The entity manager used to query for uniqueness instead of the manager of this class
      * @param string|null          $entityClass      The entity class to enforce uniqueness on instead of the current class
      * @param string|null          $repositoryMethod The repository method to check uniqueness instead of findBy. The method will receive as its argument
      *                                               a fieldName => value associative array according to the fields option configuration
      * @param string|null          $errorPath        Bind the constraint violation to this field instead of the first one in the fields option configuration
+     * @param string|null          $em               Deprecated since Symfony 7.4, use $manager instead
      */
     #[HasNamedArguments]
     public function __construct(
         array|string $fields,
         ?string $message = null,
         ?string $service = null,
-        ?string $em = null,
+        ?string $manager = null,
         ?string $entityClass = null,
         ?string $repositoryMethod = null,
         ?string $errorPath = null,
@@ -61,6 +66,7 @@ class UniqueEntity extends Constraint
         ?array $groups = null,
         $payload = null,
         ?array $options = null,
+        ?string $em = null,
     ) {
         if (\is_array($fields) && \is_string(key($fields)) && [] === array_diff(array_keys($fields), array_merge(array_keys(get_class_vars(static::class)), ['value']))) {
             trigger_deprecation('symfony/validator', '7.3', 'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.', static::class);
@@ -80,10 +86,18 @@ class UniqueEntity extends Constraint
 
         parent::__construct($options, $groups, $payload);
 
+        if (null !== $em) {
+            if ($manager !== null && $em !== $manager) {
+                throw new \InvalidArgumentException(sprintf('The "em" and "manager" options of the "%s" constraint cannot be used together with distinct values.', static::class));
+            }
+            trigger_deprecation('symfony/doctrine-bridge', '7.4', 'The "em" option of the "%s" constraint is deprecated, use "manager" instead.', static::class);
+            $manager = $em;
+        }
+
         $this->fields = $fields ?? $this->fields;
         $this->message = $message ?? $this->message;
         $this->service = $service ?? $this->service;
-        $this->em = $em ?? $this->em;
+        $this->em = $this->manager = $manager ?? $this->manager ?? $this->em;
         $this->entityClass = $entityClass ?? $this->entityClass;
         $this->repositoryMethod = $repositoryMethod ?? $this->repositoryMethod;
         $this->errorPath = $errorPath ?? $this->errorPath;

--- a/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
+++ b/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
@@ -68,11 +68,11 @@ class UniqueEntityValidator extends ConstraintValidator
 
         $entityClass = $constraint->entityClass ?? $value::class;
 
-        if ($constraint->em) {
+        if ($constraint->manager) {
             try {
-                $em = $this->registry->getManager($constraint->em);
+                $em = $this->registry->getManager($constraint->manager);
             } catch (\InvalidArgumentException $e) {
-                throw new ConstraintDefinitionException(\sprintf('Object manager "%s" does not exist.', $constraint->em), 0, $e);
+                throw new ConstraintDefinitionException(\sprintf('Object manager "%s" does not exist.', $constraint->manager), 0, $e);
             }
         } else {
             $em = $this->registry->getManagerForClass($entityClass);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Issues        | Fix https://github.com/doctrine/DoctrineMongoDBBundle/pull/918#discussion_r2322497332
| License       | MIT

I know we'll never do it.

